### PR TITLE
fesom2: gotcha for required namelist.forcing groups; inject age_tracer defaults (closes #11, #12)

### DIFF
--- a/src/fesom2/domain/forcing.py
+++ b/src/fesom2/domain/forcing.py
@@ -11,6 +11,19 @@ import yaml
 
 _FORCINGS_PATH = Path("FESOM2/setups/forcings.yml")
 
+# age_tracer namelist group defaults (gen_modules_forcing.F90:49-52).
+# setup_model reads this group unconditionally from namelist.forcing, but it is
+# absent from every entry in forcings.yml.  We inject the Fortran defaults so
+# callers always receive a complete, valid set of groups.
+_AGE_TRACER_DEFAULTS: dict = {
+    "age_tracer": {
+        "use_age_tracer": False,
+        "use_age_mask": False,
+        "age_tracer_path": "./mesh/",
+        "age_start_year": 2000,
+    }
+}
+
 
 def list_forcing_datasets(forcings_path: Path = _FORCINGS_PATH) -> list[str]:
     """Return names of all available forcing datasets."""
@@ -34,8 +47,13 @@ def get_forcing_spec(
     Returns
     -------
     dict or None
-        Keys: forcing_exchange_coeff, forcing_bulk, land_ice, nam_sbc,
-        namelist.config (if present). Returns None if not found.
+        Keys: forcing_exchange_coeff, forcing_bulk, land_ice, age_tracer,
+        nam_sbc, namelist.config (if present).
+        age_tracer is always included with Fortran defaults
+        (use_age_tracer=False, use_age_mask=False, age_tracer_path='./mesh/',
+        age_start_year=2000) even when absent from forcings.yml, because
+        setup_model reads that group unconditionally from namelist.forcing.
+        Returns None if the dataset is not found.
     """
     if not forcings_path.exists():
         return None
@@ -43,4 +61,8 @@ def get_forcing_spec(
         data = yaml.safe_load(fh) or {}
     # Case-insensitive lookup
     lookup = {k.lower(): v for k, v in data.items()}
-    return lookup.get(dataset.lower())
+    spec = lookup.get(dataset.lower())
+    if spec is None:
+        return None
+    # Inject age_tracer defaults when absent from forcings.yml
+    return {**_AGE_TRACER_DEFAULTS, **spec}

--- a/src/fesom2/domain/gotcha.py
+++ b/src/fesom2/domain/gotcha.py
@@ -130,6 +130,35 @@ CATALOGUE: list[dict] = [
         ),
     },
     {
+        "title": "Four namelist.forcing groups are always required regardless of forcing_opt",
+        "keywords": [
+            "namelist.forcing", "forcing_exchange_coeff", "forcing_bulk", "land_ice",
+            "age_tracer", "forcing_opt", "toy_ocean", "nam_sbc", "required groups",
+            "could not read namelist", "iostat", "namelist parse",
+        ],
+        "summary": (
+            "setup_model reads four namelist.forcing groups unconditionally — "
+            "forcing_exchange_coeff, forcing_bulk, land_ice, and age_tracer — "
+            "before any forcing_opt check and regardless of toy_ocean. "
+            "A missing group aborts the run even when forcing is not used."
+        ),
+        "detail": (
+            "FESOM2's setup_model (gen_model_setup.F90) opens namelist.forcing and "
+            "reads four groups before any conditional logic: forcing_exchange_coeff, "
+            "forcing_bulk, land_ice, and age_tracer. If any group is absent the "
+            "Fortran namelist parser sets iostat /= 0 and check_namelist_read aborts "
+            "the run with 'Could not read namelist <group>'. This happens even when "
+            "forcing_opt=0 or toy_ocean=.true. — the parse is unconditional. "
+            "The only conditionally-read group is nam_sbc, which is only parsed when "
+            "use_ice=.true. (inside sbc_ini called from gen_forcing_init.F90). "
+            "Safe minimal defaults for the groups most likely to be omitted: "
+            "&age_tracer use_age_tracer=.false., use_age_mask=.false., "
+            "age_tracer_path='./mesh/', age_start_year=2000 /. "
+            "Use get_forcing_spec_tool to get per-dataset values for the other three "
+            "groups; age_tracer defaults are always included in that response."
+        ),
+    },
+    {
         "title": "Forcing interpolation weights must be precomputed",
         "keywords": [
             "forcing", "interpolation", "weights", "interp", "era5", "core2",

--- a/src/fesom2/server.py
+++ b/src/fesom2/server.py
@@ -279,9 +279,11 @@ def get_forcing_spec_tool(dataset: str) -> dict | None:
     Returns
     -------
     dict or None
-        Keys: forcing_exchange_coeff, forcing_bulk, land_ice, nam_sbc,
-        and optionally namelist.config overrides.
-        Returns None if the dataset is not found.
+        Keys: forcing_exchange_coeff, forcing_bulk, land_ice, age_tracer,
+        nam_sbc (if present), and optionally namelist.config overrides.
+        age_tracer is always included with safe Fortran defaults because
+        setup_model reads it unconditionally from namelist.forcing regardless
+        of forcing_opt or toy_ocean. Returns None if the dataset is not found.
     """
     return get_forcing_spec(dataset)
 

--- a/tests/fesom2/domain/test_gotcha.py
+++ b/tests/fesom2/domain/test_gotcha.py
@@ -66,6 +66,18 @@ def test_forcing_interpolation_found():
     assert len(results) >= 1
 
 
+def test_namelist_forcing_required_groups_found():
+    results = lookup_gotcha("namelist.forcing age_tracer")
+    assert len(results) >= 1
+
+
+def test_namelist_forcing_gotcha_mentions_four_groups():
+    results = lookup_gotcha("forcing_exchange_coeff")
+    entry = next(r for r in results if "Four" in r["title"])
+    for group in ("forcing_exchange_coeff", "forcing_bulk", "land_ice", "age_tracer"):
+        assert group in entry["detail"]
+
+
 def test_output_namelist_found():
     results = lookup_gotcha("namelist.io output")
     assert len(results) >= 1


### PR DESCRIPTION
## Summary

- **Issue #11 — new gotcha**: `setup_model` reads four `namelist.forcing` groups unconditionally — `forcing_exchange_coeff`, `forcing_bulk`, `land_ice`, and `age_tracer` — before any `forcing_opt` check and regardless of `toy_ocean`. A missing group aborts with `"Could not read namelist <group>"`. The only conditionally-read group is `nam_sbc` (`use_ice=.true.`). Verified against `gen_model_setup.F90:135–147` and `gen_forcing_init.F90:43`.

- **Issue #12 Gap A — `age_tracer` injected**: `get_forcing_spec()` now injects the Fortran defaults (`use_age_tracer=False`, `use_age_mask=False`, `age_tracer_path='./mesh/'`, `age_start_year=2000`) when `age_tracer` is absent from `forcings.yml`. YAML-supplied values override defaults. Callers always receive all four unconditionally-read groups in the response.

- **Issue #12 Gap B (partial)**: `get_forcing_spec_tool` docstring now explicitly states that `age_tracer` is always present and explains why — closing the most common "how do I write a complete `namelist.forcing`?" gap for toy/idealized runs.

## Test plan

- [x] `pixi run test` — 552 tests pass
- [ ] Restart MCP server and verify `get_forcing_spec_tool("ERA5")` returns `age_tracer` key
- [ ] Verify `lookup_gotcha_tool("namelist.forcing age_tracer")` returns the new gotcha

🤖 Generated with [Claude Code](https://claude.com/claude-code)